### PR TITLE
Supporting ReactiveSwift events

### DIFF
--- a/Example/RoboKittenTests/Mocks/Generated/Mock.generated.swift
+++ b/Example/RoboKittenTests/Mocks/Generated/Mock.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.13.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.14.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Foundation

--- a/Example/SwiftyMock.xcodeproj/project.pbxproj
+++ b/Example/SwiftyMock.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		D21AF4631FC62DF600C0DC5F /* SwiftyMockReactiveCallsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21AF4611FC62CFF00C0DC5F /* SwiftyMockReactiveCallsSpec.swift */; };
 		D21AF4661FC638F200C0DC5F /* ReactiveMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21AF4641FC6324400C0DC5F /* ReactiveMatchers.swift */; };
 		D2AEE57F20F9559000FF7DC8 /* Mock.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AEE57E20F9559000FF7DC8 /* Mock.generated.swift */; };
+		D2E357F5213DE087009417DA /* SwiftyMockReactiveEventsCallsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E357F4213DE087009417DA /* SwiftyMockReactiveEventsCallsSpec.swift */; };
 		E434BE281D4AAE86000E7125 /* SwiftyMockCallsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E434BE271D4AAE86000E7125 /* SwiftyMockCallsSpec.swift */; };
 		E481D6901D4DDE61000E73AE /* RoboKittenControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E481D68F1D4DDE61000E73AE /* RoboKittenControllerSpec.swift */; };
 		EEDBE358155D115C15126670 /* RoboKitten.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDBEBCC4DF10B0C24246892 /* RoboKitten.swift */; };
@@ -63,6 +64,7 @@
 		D21AF4611FC62CFF00C0DC5F /* SwiftyMockReactiveCallsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftyMockReactiveCallsSpec.swift; sourceTree = "<group>"; };
 		D21AF4641FC6324400C0DC5F /* ReactiveMatchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactiveMatchers.swift; sourceTree = "<group>"; };
 		D2AEE57E20F9559000FF7DC8 /* Mock.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mock.generated.swift; sourceTree = "<group>"; };
+		D2E357F4213DE087009417DA /* SwiftyMockReactiveEventsCallsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftyMockReactiveEventsCallsSpec.swift; sourceTree = "<group>"; };
 		E434BE271D4AAE86000E7125 /* SwiftyMockCallsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftyMockCallsSpec.swift; sourceTree = "<group>"; };
 		E481D6831D4DDDBE000E73AE /* RoboKittenTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RoboKittenTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E481D6871D4DDDBE000E73AE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -213,6 +215,7 @@
 			children = (
 				E434BE271D4AAE86000E7125 /* SwiftyMockCallsSpec.swift */,
 				D21AF4611FC62CFF00C0DC5F /* SwiftyMockReactiveCallsSpec.swift */,
+				D2E357F4213DE087009417DA /* SwiftyMockReactiveEventsCallsSpec.swift */,
 				D21AF4641FC6324400C0DC5F /* ReactiveMatchers.swift */,
 			);
 			path = Calls;
@@ -542,6 +545,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2E357F5213DE087009417DA /* SwiftyMockReactiveEventsCallsSpec.swift in Sources */,
 				E434BE281D4AAE86000E7125 /* SwiftyMockCallsSpec.swift in Sources */,
 				D21AF4661FC638F200C0DC5F /* ReactiveMatchers.swift in Sources */,
 				D21AF4631FC62DF600C0DC5F /* SwiftyMockReactiveCallsSpec.swift in Sources */,

--- a/Example/SwiftyMock.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/SwiftyMock.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Tests/Calls/SwiftyMockCallsSpec.swift
+++ b/Example/Tests/Calls/SwiftyMockCallsSpec.swift
@@ -11,11 +11,11 @@ import Quick
 import Nimble
 @testable import SwiftyMock
 
-protocol Calculator {
+fileprivate protocol Calculator {
     func sum(left: Int, right: Int) -> Int
 }
 
-class TestCalculator: Calculator {
+fileprivate class TestCalculator: Calculator {
     let sum = FunctionCall<(left: Int, right: Int), Int>()
     @discardableResult func sum(left: Int, right: Int) -> Int {
         return stubCall(sum, argument: (left: left, right: right))

--- a/Example/Tests/Calls/SwiftyMockReactiveCallsSpec.swift
+++ b/Example/Tests/Calls/SwiftyMockReactiveCallsSpec.swift
@@ -13,11 +13,11 @@ import ReactiveSwift
 import Result
 @testable import SwiftyMock
 
-protocol ReactiveCalculator {
+fileprivate protocol ReactiveCalculator {
     func sum(left: Int, right: Int) -> SignalProducer<Int, TestError>
 }
 
-class TestReactiveCalculator: ReactiveCalculator {
+fileprivate class TestReactiveCalculator: ReactiveCalculator {
     init() {}
 
     let sum = ReactiveCall<(left: Int, right: Int), Int, TestError>()
@@ -26,7 +26,7 @@ class TestReactiveCalculator: ReactiveCalculator {
     }
 }
 
-struct TestError: Error, Equatable {
+fileprivate struct TestError: Error, Equatable {
     let id: Int
     init() { id = 0 }
     init(id: Int) { self.id = id }
@@ -57,7 +57,7 @@ class SwiftyMockReactiveCallsSpec: QuickSpec {
                 }
 
                 context("when calling method before stubbing") {
-                    fit("should return empty signal without any value") {
+                    it("should return empty signal without any value") {
                         expect { sut.sum(left: 1,right: 2) }.to(complete())
                     }
                 }
@@ -224,8 +224,8 @@ class SwiftyMockReactiveCallsSpec: QuickSpec {
                 context("when calling filtered stubbed with block method") {
                     beforeEach {
                         sut.sum.returns(.success(17))
-                        sut.sum.on { $0.left  == 12 }.performs { .success($0.left - $0.right) }
-                        sut.sum.on { $0.right == 42 }.performs { _ in .failure(TestError()) }
+                        sut.sum.on { $0.left == 12 }.performs { .success($0.left - $0.right) }
+                        sut.sum.on { $0.left == 42 }.performs { _ in .failure(TestError()) }
                     }
                     context("when parameters matching filter") {
                         it("should return calculated with stub value") {

--- a/Example/Tests/Calls/SwiftyMockReactiveEventsCallsSpec.swift
+++ b/Example/Tests/Calls/SwiftyMockReactiveEventsCallsSpec.swift
@@ -1,0 +1,248 @@
+//
+//  SwiftyMockReactiveEventsCallsSpec.swift
+//  SwiftyMock_Tests
+//
+//  Created by Alexander Voronov on 9/4/18.
+//  Copyright © 2018 CocoaPods. All rights reserved.
+//
+
+import Foundation
+import Quick
+import Nimble
+import ReactiveSwift
+import Result
+@testable import SwiftyMock
+
+fileprivate protocol ReactiveCalculator {
+    func sum(left: Int, right: Int) -> SignalProducer<Int, TestError>
+}
+
+fileprivate class TestReactiveCalculator: ReactiveCalculator {
+    init() {}
+
+    let sum = ReactiveEventsCall<(left: Int, right: Int), Int, TestError>()
+    @discardableResult func sum(left: Int, right: Int) -> SignalProducer<Int, TestError> {
+        return stubCall(sum, argument: (left: left, right: right))
+    }
+}
+
+fileprivate struct TestError: Error, Equatable {
+    let id: Int
+    init() { id = 0 }
+    init(id: Int) { self.id = id }
+}
+
+class SwiftyMockReactiveEventsCallsSpec: QuickSpec {
+    override func spec() {
+        describe("SwiftyMockReactiveEventsCalls") {
+            describe("when correctly setup") {
+                var sut: TestReactiveCalculator!
+                beforeEach {
+                    sut = TestReactiveCalculator()
+                }
+
+                context("before calling stubbed method") {
+                    it("should tell that method wasn't called") {
+                        expect(sut.sum.called).to(beFalsy())
+                    }
+                    it("should have calls count equal to zero") {
+                        expect(sut.sum.callsCount).to(equal(0))
+                    }
+                    it("should not have captured argument") {
+                        expect(sut.sum.capturedArgument).to(beNil())
+                    }
+                    it("should not have captured arguments") {
+                        expect(sut.sum.capturedArguments).to(beEmpty())
+                    }
+                }
+
+                context("when calling method before stubbing") {
+                    it("should return empty signal without any value") {
+                        expect { sut.sum(left: 1,right: 2) }.to(complete())
+                    }
+                }
+
+                context("when calling stubbed method") {
+                    context("with value stub") {
+                        beforeEach {
+                            sut.sum.returns(.value(12))
+                        }
+
+                        it("should return stubbed value and complete") {
+                            let result = sut.sum(left: 1, right: 2)
+                            expect(result).to(sendEvents([.value(12), .completed]))
+                        }
+
+                        it("should have calls count equal number of calls") {
+                            sut.sum(left: 1, right: 2)
+                            expect(sut.sum.callsCount).to(equal(1))
+
+                            sut.sum(left: 2, right: 3)
+                            sut.sum(left: 3, right: 5)
+                            expect(sut.sum.callsCount).to(equal(3))
+                        }
+
+                        it("should tell that method was called") {
+                            sut.sum(left: 1,right: 2)
+                            expect(sut.sum.called).to(beTruthy())
+                        }
+                    }
+
+                    context("with failure value stub") {
+                        beforeEach {
+                            sut.sum.returns(.failed(TestError()))
+                        }
+
+                        it("should return stubbed error") {
+                            expect(sut.sum(left: 1, right: 2)).to(fail(with: TestError()))
+                        }
+                    }
+
+                    context("with logic stub") {
+                        beforeEach {
+                            sut.sum.performs { .value($0.left - $0.right) }
+                        }
+
+                        it("should calculate method based on the stubbed block") {
+                            expect(sut.sum(left: 1, right: 2)).to(sendValue(-1))
+                            expect(sut.sum(left: 3, right: 2)).to(sendValue(1))
+                        }
+
+                        it("should have calls count equal number of calls") {
+                            sut.sum(left: 1, right: 2)
+                            expect(sut.sum.callsCount).to(equal(1))
+
+                            sut.sum(left: 2, right: 3)
+                            sut.sum(left: 3, right: 5)
+                            expect(sut.sum.callsCount).to(equal(3))
+                        }
+
+                        it("tell that method was called") {
+                            sut.sum(left: 1, right:2)
+                            expect(sut.sum.called).to(beTruthy())
+                        }
+                    }
+
+                    context("with failure logic stub") {
+                        beforeEach {
+                            sut.sum.performs { _ in [.failed(TestError())] }
+                        }
+
+                        it("should return stubbed error") {
+                            expect(sut.sum(left: 1, right: 2)).to(fail(with: TestError()))
+                        }
+                    }
+
+                    context("with value and logic stub") {
+                        beforeEach {
+                            sut.sum.returns(.value(12))
+                            sut.sum.performs { [.value($0.left + $0.right)] }
+                        }
+
+                        it("should use logic stub instead of value") {
+                            expect(sut.sum(left: 15, right: 12)).to(sendValue(27))
+                        }
+                    }
+
+                    context("with value and failure logic stub") {
+                        beforeEach {
+                            sut.sum.returns(.value(12))
+                            sut.sum.performs { _ in [.failed(TestError())] }
+                        }
+
+                        it("should use failure logic stub instead of value") {
+                            expect(sut.sum(left: 15, right: 12)).to(fail(with: TestError()))
+                        }
+                    }
+
+                    context("with failure value and logic stub") {
+                        beforeEach {
+                            sut.sum.returns([.failed(TestError())])
+                            sut.sum.performs { .value($0.left + $0.right) }
+                        }
+
+                        it("should use logic stub instead of failure value") {
+                            expect(sut.sum(left: 15, right: 12)).to(sendValue(27))
+                        }
+                    }
+
+                    context("with failure value and failure logic stub") {
+                        beforeEach {
+                            sut.sum.returns([.failed(TestError(id: 0))])
+                            sut.sum.performs { _ in [.failed(TestError(id: 1))] }
+                        }
+
+                        it("should use failure logic stub instead of failure value") {
+                            expect(sut.sum(left: 15, right: 12)).to(fail(with: TestError(id: 1)))
+                        }
+                    }
+                }
+
+                context("when calling filtered value stubbed method") {
+                    beforeEach {
+                        sut.sum.returns([.value(10)])
+                        sut.sum.on { $0.left  == 12 }.returns(.value(0))
+                        sut.sum.on { $0.right == 15 }.returns([.value(7)])
+                        sut.sum.on { $0.right == 42 }.returns([.failed(TestError())])
+                    }
+                    context("when parameters matching filter") {
+                        it("should return filter srubbed value") {
+                            expect(sut.sum(left: 12, right:  2)).to(sendValue(0))
+                            expect(sut.sum(left: 0,  right: 15)).to(sendValue(7))
+                            expect(sut.sum(left: 23, right: 42)).to(fail(with: TestError()))
+                        }
+                    }
+                    context("when parameters don't match filters") {
+                        it("should return default stubbed value") {
+                            expect(sut.sum(left: 13, right: 2)).to(sendValue(10))
+                        }
+                    }
+                }
+
+                context("when calling filtered block stubbed method") {
+                    beforeEach {
+                        sut.sum.performs { [.value($0.left - $0.right)] }
+                        sut.sum.on { $0.left  == 0  }.performs { _ in [.value(0)] }
+                        sut.sum.on { $0.right == 0  }.performs { _ in .value(12) }
+                        sut.sum.on { $0.right == -1 }.performs { _ in [.failed(TestError())] }
+                    }
+                    context("when parameters matching filter") {
+                        it("should return call filter-based block") {
+                            expect(sut.sum(left: 0,  right:  2)).to(sendValue(0))
+                            expect(sut.sum(left: 15, right:  0)).to(sendValue(12))
+                            expect(sut.sum(left: 15, right: -1)).to(fail(with: TestError()))
+                        }
+                    }
+                    context("when parameters don't match filters") {
+                        it("should call default stubbed block") {
+                            expect(sut.sum(left: 13, right: 2)).to(sendValue(11))
+                        }
+                    }
+                }
+
+                context("when calling filtered stubbed with block method") {
+                    beforeEach {
+                        sut.sum.returns([.value(17)])
+                        sut.sum.on { $0.left == 12 }.performs { [.value($0.left - $0.right)] }
+                        sut.sum.on { $0.right == 13 }.performs { _ in [.value(42), .interrupted] }
+                        sut.sum.on { $0.left == 42 }.performs { _ in .failed(TestError()) }
+                    }
+                    context("when parameters matching filter") {
+                        it("should return calculated with stub value") {
+                            expect(sut.sum(left: 12, right:  2)).to(sendValue(10))
+                            expect(sut.sum(left: 12, right: 12)).to(sendValue(0))
+                            expect(sut.sum(left: 0, right: 13)).to(interrupt())
+                            expect(sut.sum(left: 1, right: 13)).to(sendEvents([.value(42), .interrupted]))
+                            expect(sut.sum(left: 42, right: 12)).to(fail(with: TestError()))
+                        }
+                    }
+                    context("when parameters don't match filters") {
+                        it("should return default stubbed value") {
+                            expect(sut.sum(left: 13, right: 2)).to(sendValue(17))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -181,8 +181,26 @@ kittenMock.batteryStatusCall.returns(Result(error: ImagineThisIsError))
 
 Everything else stays the same :)
 
+### Advanced
+Usually Result is enough to stub signal with either value or error. But since Signal represents sequence of values over time, you might want to stub this behaviour as well.    
+For this purpose, there's `ReactiveEventsCall` which is actually a `FunctionCall` with `Array<Signal.Event>` value type.    
+This way you can stub function return value with sequence of events. But don't forget about [Event contract](https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Documentation/APIContracts.md#the-event-contract) - thus no value will be sent after any terminating event.
+
+```swift
+// when using Result:
+kittenMock.batteryStatusCall.returns(.success(42))
+
+// when using Signal.Event - you can pass either one event, or many as shown below:
+// also `.completed` event will be called automatically if no terminating event passed in the sequence, thus `[.value(42), .completed] == .value(42)`
+kittenMock.batteryStatusCall.returns(.value(42))
+// or
+kittenMock.batteryStatusCall.returns([.value(42), .value(12), .value(0), .completed])
+// but this one won't send `.value(0)`, since it has already completed before it
+kittenMock.batteryStatusCall.returns([.value(42), .completed, .value(0)])
+```
+
 # Matchers
-SwiftyMock doesn't have its own matchers, so you can use whatever matchers suits better for you :)
+SwiftyMock doesn't have its own matchers, so you can use whatever matchers suit you better :)
 
 # Templates
 You can generate mocks automatically with [Sourcery](https://github.com/krzysztofzablocki/Sourcery).    

--- a/SwiftyMock/Classes/Core/MockUtils.swift
+++ b/SwiftyMock/Classes/Core/MockUtils.swift
@@ -47,6 +47,18 @@ open class FunctionCall<Arg, Value> {
     }
 }
 
+public extension FunctionCall {
+    public func returns<E>(_ element: E) where Value == Array<E> {
+        returns([element])
+    }
+
+    public func performs<E>(_ block: @escaping (Arg) -> E) where Value == Array<E> {
+        performs({ arg in [block(arg)] })
+    }
+}
+
+// MARK: - Stub Call
+
 public func stubCall<Arg, Value>(_ call: FunctionCall<Arg, Value>, argument: Arg, defaultValue: Value? = nil)  -> Value {
     call.capture(argument)
     
@@ -89,14 +101,28 @@ open class ReturnContext<Arg, Value> {
         self.stub = stub
     }
 
-    @discardableResult open func returns(_ value: Value) -> FunctionCall<Arg, Value> {
+    @discardableResult
+    open func returns(_ value: Value) -> FunctionCall<Arg, Value> {
         stub.stubbedValue = value
         return call
     }
 
-    @discardableResult open func performs(_ block: @escaping ((Arg) -> Value)) -> FunctionCall<Arg, Value> {
+    @discardableResult
+    open func performs(_ block: @escaping ((Arg) -> Value)) -> FunctionCall<Arg, Value> {
         stub.stubbedBlock = block
         return call
+    }
+}
+
+public extension ReturnContext {
+    @discardableResult
+    public func returns<E>(_ element: E) -> FunctionCall<Arg, Value> where Value == Array<E> {
+        return returns([element])
+    }
+
+    @discardableResult
+    public func performs<E>(_ block: @escaping ((Arg) -> E)) -> FunctionCall<Arg, Value> where Value == Array<E> {
+        return performs({ arg in [block(arg)] })
     }
 }
 

--- a/SwiftyMock/Classes/ReactiveCocoa/ReactiveExtensions.swift
+++ b/SwiftyMock/Classes/ReactiveCocoa/ReactiveExtensions.swift
@@ -13,6 +13,9 @@ import Result
 public typealias ReactiveCall<Arg, Value, Err: Error> = FunctionCall<Arg, Result<Value, Err>>
 public typealias ReactiveVoidCall<Value, Err: Error> = FunctionVoidCall<Result<Value, Err>>
 
+public typealias ReactiveEventsCall<Arg, Value, Err: Error> = FunctionCall<Arg, [Signal<Value, Err>.Event]>
+public typealias ReactiveEventsVoidCall<Value, Err: Error> = FunctionVoidCall<[Signal<Value, Err>.Event]>
+
 // Stub Signal Producer Call
 
 public func stubCall<Arg, Value, Err>(_ call: ReactiveCall<Arg, Value, Err>, argument: Arg, defaultValue: Result<Value, Err>? = nil) -> SignalProducer<Value, Err> {
@@ -30,10 +33,61 @@ public func stubCall<Arg, Value, Err>(_ call: ReactiveCall<Arg, Value, Err>, arg
     return SignalProducer(result: result)
 }
 
+public func stubCall<Arg, Value, Err>(_ call: ReactiveEventsCall<Arg, Value, Err>, argument: Arg, defaultEvents: [Signal<Value, Err>.Event] = []) -> SignalProducer<Value, Err> {
+
+    // returning empty signal producer if no default value provide, thus preventing failure assert
+    if call.stubbedBlocks.isEmpty && call.stubbedBlock == nil && call.stubbedValue == nil && defaultEvents.isEmpty {
+        call.capture(argument)
+        return .empty
+    }
+
+    // otherwise - duplicate normal function stubbing flow
+    call.capture(argument)
+
+    // and returning signal producer by sending all events
+    return SignalProducer { (observer, lifetime) in
+        // we're sending completed event in case array of events doesn't contain one of event that completes signal: (interrupted | completed | failed)
+        // if there's one of such events, observer won't send another one completing event, thus nothing will happen
+        defer { observer.sendCompleted() }
+
+        for stub in call.stubbedBlocks {
+            if stub.filter(argument) {
+                if case let .some(stubbedBlock) = stub.stubbedBlock {
+                    return stubbedBlock(argument).forEach(observer.send)
+                }
+
+                if case let .some(stubbedValue) = stub.stubbedValue {
+                    return stubbedValue.forEach(observer.send)
+                }
+            }
+        }
+
+        if case let .some(stubbedBlock) = call.stubbedBlock {
+            return stubbedBlock(argument).forEach(observer.send)
+        }
+
+        if case let .some(stubbedValue) = call.stubbedValue {
+            return stubbedValue.forEach(observer.send)
+        }
+
+        if !defaultEvents.isEmpty {
+            return defaultEvents.forEach(observer.send)
+        }
+
+        assertionFailure("stub doesnt' have events to send")
+
+        return call.stubbedValue!.forEach(observer.send)
+    }
+}
+
 // MARK: - Function Call Mock/Stub/Spy Without Arguments
 
 public func stubCall<Value, Err>(_ call: ReactiveVoidCall<Value, Err>, defaultValue: Result<Value, Err>? = nil) -> SignalProducer<Value, Err> {
     return stubCall(call, argument: (), defaultValue: defaultValue)
+}
+
+public func stubCall<Value, Err>(_ call: ReactiveEventsVoidCall<Value, Err>, defaultEvents: [Signal<Value, Err>.Event] = []) -> SignalProducer<Value, Err> {
+    return stubCall(call, argument: (), defaultEvents: defaultEvents)
 }
 
 // MARK: - Stub Action Call


### PR DESCRIPTION
Now we can mock calls with Signal.Event or sequence of them (corresponding to [Event contract](https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Documentation/APIContracts.md#the-event-contract))
i.e. comparing `Result` with `Signal.Event`:
```swift
sut.sum.on { $0.right == 15 }.returns(.success(7))
// is identical to:
sut.sum.on { $0.right == 15 }.returns([.value(7), .completed])
// or this, since it adds completion event in the end of events sequence
// and if there’s no terminating event, complete will fire
// otherwise signal will terminate with any terminating event and stop sending any further events (see Event contract)
sut.sum.on { $0.right == 15 }.returns(.value(7))
```
and you can also have sequence of value events:
```swift
sut.fact.returns([.value(1), .value(1), .value(2), .value(6), .value(24), .completed])
```

will add more tests for sequence of events, but idea stays the same :)